### PR TITLE
Frontend refactor

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine3.15
+
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /app
+WORKDIR /app
+
+COPY ./backend/ /app
+COPY requirements.txt /app
+COPY .env /app
+RUN apk add --no-cache --virtual .build-deps \
+    ca-certificates gcc postgresql-dev linux-headers musl-dev \
+    libffi-dev jpeg-dev zlib-dev 
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -r requirements.txt
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8001"]

--- a/backend/api_workers/serializers.py
+++ b/backend/api_workers/serializers.py
@@ -1,15 +1,27 @@
 from rest_framework import serializers
-from lannister_auth.models import LannisterUser
-from lannister_requests.models import BonusRequest
+from lannister_auth.models import LannisterUser, Role
+
+
+class RoleSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="get_id_display")
+
+    class Meta:
+        model = Role
+        fields = ("name",)
 
 
 class WorkerSerializer(serializers.ModelSerializer):
+    roles = RoleSerializer(many=True, read_only=True)
+
     class Meta:
         model = LannisterUser
-        fields = "__all__"
-
-
-class RequestSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = BonusRequest
-        fields = "__all__"
+        fields = [
+            "id",
+            "username",
+            "email",
+            "first_name",
+            "last_name",
+            "slack_user_id",
+            "slack_channel_id",
+            "roles",
+        ]

--- a/backend/api_workers/urls.py
+++ b/backend/api_workers/urls.py
@@ -1,10 +1,18 @@
 from django.urls import path
-from .views import ListWorker, DetailWorker, ListWorkerRequest, DetailWorkerRequest
+from .views import (
+    ListWorkers,
+    DetailWorker,
+    ListWorkerRequest,
+    DetailWorkerRequest,
+)
 
 urlpatterns = [
-    path("", ListWorker.as_view()),
-    path("<int:pk>/", DetailWorker.as_view()),
-    path("<str:username>/", DetailWorker.as_view()),
+    # viewset-like url mapping,
+    # 'workers/' should've been renamed in root to distinguish whether url is returning single object or collection
+    path("list/", ListWorkers.as_view()),
+    path("list/<str:reviewers>/", ListWorkers.as_view()),
+    path("detail/<int:pk>/", DetailWorker.as_view()),
+    path("detail/<str:username>/", DetailWorker.as_view()),
     path("request/", ListWorkerRequest.as_view()),
     path("request/<int:pk>/", DetailWorkerRequest.as_view()),
 ]

--- a/backend/api_workers/urls.py
+++ b/backend/api_workers/urls.py
@@ -4,7 +4,7 @@ from .views import ListWorker, DetailWorker, ListWorkerRequest, DetailWorkerRequ
 urlpatterns = [
     path("", ListWorker.as_view()),
     path("<int:pk>/", DetailWorker.as_view()),
-    path("<str:slack_channel_id>/", DetailWorker.as_view()),
+    path("<str:username>/", DetailWorker.as_view()),
     path("request/", ListWorkerRequest.as_view()),
     path("request/<int:pk>/", DetailWorkerRequest.as_view()),
 ]

--- a/backend/api_workers/urls.py
+++ b/backend/api_workers/urls.py
@@ -4,6 +4,7 @@ from .views import ListWorker, DetailWorker, ListWorkerRequest, DetailWorkerRequ
 urlpatterns = [
     path("", ListWorker.as_view()),
     path("<int:pk>/", DetailWorker.as_view()),
+    path("<str:slack_channel_id>/", DetailWorker.as_view()),
     path("request/", ListWorkerRequest.as_view()),
     path("request/<int:pk>/", DetailWorkerRequest.as_view()),
 ]

--- a/backend/api_workers/views.py
+++ b/backend/api_workers/views.py
@@ -3,6 +3,7 @@ from lannister_auth.models import LannisterUser
 from lannister_requests.models import BonusRequest
 from .serializers import WorkerSerializer
 from lannister_requests.serializers import BonusRequestBaseSerializer
+from django.shortcuts import get_object_or_404
 
 
 class ListWorker(generics.ListCreateAPIView):
@@ -13,6 +14,14 @@ class ListWorker(generics.ListCreateAPIView):
 class DetailWorker(generics.RetrieveUpdateDestroyAPIView):
     queryset = LannisterUser.objects.all()
     serializer_class = WorkerSerializer
+
+    def get_object(self, *args, **kwargs):
+        if self.kwargs.get("pk"):
+            return get_object_or_404(LannisterUser, id=self.kwargs.get("pk"))
+
+        return get_object_or_404(
+            LannisterUser, slack_channel_id=self.kwargs.get("slack_channel_id")
+        )
 
 
 class ListWorkerRequest(generics.ListCreateAPIView):

--- a/backend/api_workers/views.py
+++ b/backend/api_workers/views.py
@@ -16,12 +16,13 @@ class DetailWorker(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = WorkerSerializer
 
     def get_object(self, *args, **kwargs):
+        """
+        Parsing object by model id or slack_channel_id
+        """
         if self.kwargs.get("pk"):
             return get_object_or_404(LannisterUser, id=self.kwargs.get("pk"))
 
-        return get_object_or_404(
-            LannisterUser, slack_channel_id=self.kwargs.get("slack_channel_id")
-        )
+        return get_object_or_404(LannisterUser, username=self.kwargs.get("username"))
 
 
 class ListWorkerRequest(generics.ListCreateAPIView):

--- a/backend/api_workers/views.py
+++ b/backend/api_workers/views.py
@@ -1,5 +1,6 @@
-from rest_framework import generics
-from lannister_auth.models import LannisterUser
+from rest_framework import generics, status
+from rest_framework.response import Response
+from lannister_auth.models import LannisterUser, Role
 from lannister_requests.models import BonusRequest
 from .serializers import WorkerSerializer
 from lannister_requests.serializers import BonusRequestBaseSerializer
@@ -29,6 +30,20 @@ class DetailWorker(generics.RetrieveUpdateDestroyAPIView):
             return get_object_or_404(LannisterUser, id=self.kwargs.get("pk"))
 
         return get_object_or_404(LannisterUser, username=self.kwargs.get("username"))
+
+    def patch(self, request, *args, **kwargs):
+        """
+        TODO: Lock PATCH method under permission for admin only
+        Pass integer as role
+        """
+        data = request.data
+        user = LannisterUser.objects.get(username=self.kwargs.get("username"))
+        provided_role = Role.objects.get(id=data.get("role"))
+        user.roles.remove(provided_role)
+        return Response(
+            data={"response": "User was unassigned successfully"},
+            status=status.HTTP_200_OK,
+        )
 
 
 class ListWorkerRequest(generics.ListCreateAPIView):

--- a/backend/api_workers/views.py
+++ b/backend/api_workers/views.py
@@ -2,7 +2,7 @@ from rest_framework import generics
 from lannister_auth.models import LannisterUser
 from lannister_requests.models import BonusRequest
 from .serializers import WorkerSerializer
-from .serializers import RequestSerializer
+from lannister_requests.serializers import BonusRequestBaseSerializer
 
 
 class ListWorker(generics.ListCreateAPIView):
@@ -17,9 +17,9 @@ class DetailWorker(generics.RetrieveUpdateDestroyAPIView):
 
 class ListWorkerRequest(generics.ListCreateAPIView):
     queryset = BonusRequest.objects.all()
-    serializer_class = RequestSerializer
+    serializer_class = BonusRequestBaseSerializer
 
 
 class DetailWorkerRequest(generics.RetrieveUpdateDestroyAPIView):
     queryset = BonusRequest.objects.all()
-    serializer_class = RequestSerializer
+    serializer_class = BonusRequestBaseSerializer

--- a/backend/api_workers/views.py
+++ b/backend/api_workers/views.py
@@ -6,9 +6,15 @@ from lannister_requests.serializers import BonusRequestBaseSerializer
 from django.shortcuts import get_object_or_404
 
 
-class ListWorker(generics.ListCreateAPIView):
+class ListWorkers(generics.ListCreateAPIView):
     queryset = LannisterUser.objects.all()
     serializer_class = WorkerSerializer
+
+    def get_queryset(self):
+        # very stupid way of getting optional url, refactor it later with smarter drf tools
+        if self.kwargs.get("reviewers"):
+            return LannisterUser.objects.filter(roles__in=[2])
+        return self.queryset.all()
 
 
 class DetailWorker(generics.RetrieveUpdateDestroyAPIView):

--- a/backend/lannister_auth/models.py
+++ b/backend/lannister_auth/models.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import pre_save
 from django.utils.translation import gettext_lazy as _
 
+
 class BaseManager(BaseUserManager):
     def get_or_none(self, **kwargs):
         try:
@@ -18,7 +19,7 @@ class BaseManager(BaseUserManager):
 
 class LannisterUserManager(BaseManager):
     def create_user(
-            self, email, username, password, first_name, last_name, **other_fields
+        self, email, username, password, first_name, last_name, **other_fields
     ):
         if not username:
             raise ValueError(_("Please provide username"))
@@ -38,7 +39,7 @@ class LannisterUserManager(BaseManager):
         return user
 
     def create_superuser(
-            self, email, username, password, first_name, last_name, **other_fields
+        self, email, username, password, first_name, last_name, **other_fields
     ):
         user = self.create_user(email, username, password, first_name, last_name)
         user.is_superuser = True
@@ -67,11 +68,7 @@ class Role(models.Model):
 
     id = models.PositiveSmallIntegerField(choices=USER_ROLE_CHOISES, primary_key=True)
     users = models.ManyToManyField("LannisterUser")
-    name = models.CharField(
-        max_length=20, choices=USER_ROLE_CHOISES, default=3
-    )  # get_user_display()
     description = models.CharField(max_length=128, null=True)
-    users = models.ManyToManyField("LannisterUser", related_name="users")
 
     def __str__(self):
         return self.get_id_display()

--- a/backend/lannister_core/settings.py
+++ b/backend/lannister_core/settings.py
@@ -15,7 +15,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("SECRET_KEY")
-print(SECRET_KEY)
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 

--- a/backend/lannister_requests/models.py
+++ b/backend/lannister_requests/models.py
@@ -64,7 +64,7 @@ class BonusRequest(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return f"{self.creator}'s bonus request. Reviewer assigned - {self.reviewer}"
+        return f"id: {self.pk} {self.creator}'s bonus request. Reviewer assigned - {self.reviewer}"
 
     class Meta:
         db_table = "bonus_requests"

--- a/backend/lannister_requests/permissions.py
+++ b/backend/lannister_requests/permissions.py
@@ -1,14 +1,20 @@
-from rest_framework.permissions import BasePermission
+from rest_framework.permissions import IsAuthenticated, SAFE_METHODS
 
 """
 Skeleton for Roles implementing
 """
 
 
-class IsUser(BasePermission):
-    allowed_methods = ["GET", "POST", "PUT", "PATCH"]
-
-    def has_object_permission(self, request, view, obj):
-        if request.method in self.allowed_methods:
+class IsUser(IsAuthenticated):
+    def has_permission(self, request, view):
+        # custom header is neccessary for the frontend to bypass jwt token verification of IsAuthenticated class, note: possible security breach
+        if request.META.get("HTTP_X_SLACK_FRONTEND") == "slack-frontend-header":
             return True
-        return obj.creator.username == request.user.username
+
+        if not super().has_permission(request, view):
+            return False
+
+        if request.method in SAFE_METHODS:
+            return True
+
+        # return request.creator.username == request.user.username

--- a/backend/lannister_requests/serializers.py
+++ b/backend/lannister_requests/serializers.py
@@ -34,6 +34,8 @@ class BonusRequestRewieverSerializer(ModelSerializer):
 
 class BonusRequestBaseSerializer(ModelSerializer):
     status = SerializerMethodField()
+    creator = SerializerMethodField()
+    reviewer = SerializerMethodField()
 
     class Meta:
         model = BonusRequest
@@ -48,6 +50,14 @@ class BonusRequestBaseSerializer(ModelSerializer):
 
     def get_status(self, obj):
         return obj.status.status_name
+
+    def get_creator(self, obj):
+        return obj.creator.username
+
+    def get_reviewer(self, obj):
+        if not obj.reviewer:
+            return None
+        return obj.reviewer.username
 
 
 class BonusRequestHistorySerializer(ModelSerializer):

--- a/backend/lannister_requests/serializers.py
+++ b/backend/lannister_requests/serializers.py
@@ -1,4 +1,7 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import (
+    ModelSerializer,
+    SerializerMethodField,
+)
 from lannister_requests.models import (
     BonusRequest,
     BonusRequestsHistory,
@@ -30,6 +33,8 @@ class BonusRequestRewieverSerializer(ModelSerializer):
 
 
 class BonusRequestBaseSerializer(ModelSerializer):
+    status = SerializerMethodField()
+
     class Meta:
         model = BonusRequest
         fields = "__all__"
@@ -40,6 +45,9 @@ class BonusRequestBaseSerializer(ModelSerializer):
             "price_usd",
             "payment_date",
         )
+
+    def get_status(self, obj):
+        return obj.status.status_name
 
 
 class BonusRequestHistorySerializer(ModelSerializer):
@@ -75,3 +83,15 @@ class BonusRequestStatusSerializer(ModelSerializer):
     class Meta:
         model = BonusRequestStatus
         fields = "__all__"
+
+
+class BonusTypeSerializer(ModelSerializer):
+    bonus_type = SerializerMethodField()
+
+    class Meta:
+        fields = ["bonus_type"]
+        model = BonusRequest
+
+    def get_bonus_type(self, obj):
+        print(obj)
+        return obj  # bonus type returns tuple for some reason

--- a/backend/lannister_requests/serializers.py
+++ b/backend/lannister_requests/serializers.py
@@ -112,5 +112,4 @@ class BonusTypeSerializer(ModelSerializer):
         model = BonusRequest
 
     def get_bonus_type(self, obj):
-        print(obj)
-        return obj  # bonus type returns tuple for some reason
+        return obj

--- a/backend/lannister_requests/serializers.py
+++ b/backend/lannister_requests/serializers.py
@@ -80,6 +80,7 @@ class BonusRequestHistorySerializer(ModelSerializer):
 
 class FullHistorySerializer(ModelSerializer):
     history_requests = BonusRequestHistorySerializer(many=True, read_only=True)
+    creator = SerializerMethodField()
 
     class Meta:
         model = BonusRequest
@@ -92,6 +93,9 @@ class FullHistorySerializer(ModelSerializer):
             "payment_date",
             "history_requests",
         ]
+
+    def get_creator(self, obj):
+        return obj.creator.username
 
 
 class BonusRequestStatusSerializer(ModelSerializer):

--- a/backend/lannister_requests/serializers.py
+++ b/backend/lannister_requests/serializers.py
@@ -61,6 +61,8 @@ class BonusRequestBaseSerializer(ModelSerializer):
 
 
 class BonusRequestHistorySerializer(ModelSerializer):
+    status = SerializerMethodField()
+
     class Meta:
         model = BonusRequestsHistory
         fields = (
@@ -71,6 +73,9 @@ class BonusRequestHistorySerializer(ModelSerializer):
             "status",
             "updated_at",
         )
+
+    def get_status(self, obj):
+        return obj.status.status_name
 
 
 class FullHistorySerializer(ModelSerializer):

--- a/backend/lannister_requests/urls.py
+++ b/backend/lannister_requests/urls.py
@@ -1,13 +1,30 @@
-from django.urls import path, include
-from lannister_requests.views import BonusRequestViewSet, HistoryRequestViewSet, BonusRequestStatusViewSet
-from rest_framework.routers import DefaultRouter
+from django.urls import path
+from lannister_requests.views import (
+    BonusRequestViewSet,
+    BonusTypeView,
+    HistoryRequestViewSet,
+    BonusRequestStatusViewSet,
+)
 
 
 urlpatterns = [
-    path("", BonusRequestViewSet.as_view({'get': 'list', 'post': 'create'})),
-    path("<pk>", BonusRequestViewSet.as_view({'get': 'retrieve', 'delete': 'destroy', 'patch': 'partial_update'})),
-    path("history/<pk>", HistoryRequestViewSet.as_view({'get': 'retrieve'})),
-    path("history/", HistoryRequestViewSet.as_view({'get': 'list'})),
-    path("status/", BonusRequestStatusViewSet.as_view({'get': 'list', 'post': 'create'})),
-    path("status/<pk>", BonusRequestStatusViewSet.as_view({'get': 'retrieve', 'delete': 'destroy', 'patch': 'partial_update'})),
+    path("", BonusRequestViewSet.as_view({"get": "list", "post": "create"})),
+    path(
+        "<pk>",
+        BonusRequestViewSet.as_view(
+            {"get": "retrieve", "delete": "destroy", "patch": "partial_update"}
+        ),
+    ),
+    path("history/<pk>", HistoryRequestViewSet.as_view({"get": "retrieve"})),
+    path("history/", HistoryRequestViewSet.as_view({"get": "list"})),
+    path(
+        "status/", BonusRequestStatusViewSet.as_view({"get": "list", "post": "create"})
+    ),
+    path(
+        "status/<pk>",
+        BonusRequestStatusViewSet.as_view(
+            {"get": "retrieve", "delete": "destroy", "patch": "partial_update"}
+        ),
+    ),
+    path("bonus-types/", BonusTypeView.as_view({"get": "list"})),
 ]

--- a/backend/lannister_requests/views.py
+++ b/backend/lannister_requests/views.py
@@ -1,4 +1,5 @@
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from lannister_auth.models import LannisterUser, Role
 from lannister_requests.models import BonusRequest, BonusRequestStatus
 
 # from lannister_slack.serializers import BonusRequestSerializer
@@ -8,16 +9,16 @@ from lannister_requests.serializers import (
     BonusRequestBaseSerializer,
     FullHistorySerializer,
     BonusRequestStatusSerializer,
+    BonusTypeSerializer,
 )
 from rest_framework.permissions import IsAuthenticated
 from lannister_requests.permissions import IsUser
+from rest_framework.response import Response
+from rest_framework import status
 
 
 class BonusRequestViewSet(ModelViewSet):
-    permission_classes = (
-        IsAuthenticated,
-        IsUser,
-    )
+    permission_classes = (IsUser,)
     queryset = BonusRequest.objects.all()
 
     # serializer_class = BonusRequestSerializer
@@ -39,14 +40,57 @@ class BonusRequestViewSet(ModelViewSet):
 
     def get_queryset(self):
         """
-        Another queryset for each groups
-        NOW MOCK TILL HAVEN`T PERMISSIONS AND ROLE IMPLEMENT
+        Handles query parameter like: /api/requests/?user=demigorrgon, to find bonus requests by user
+        returns list if called on collection aka /api/requests/?user=demigorrgon
+        returns single element on /api/requests/1?user=demigorrgon
         """
-        queryset = self.queryset.all()
-        return queryset
+        if self.request.query_params.get("user"):
+            queryset = self.queryset.filter(
+                creator__username=self.request.query_params.get("user")
+            )
+            return queryset
+        return self.queryset
 
-    def perform_create(self, serializer):
-        serializer.save(creator=self.request.user)
+    # def perform_create(self, serializer):
+    #     serializer.save(creator=self.request.user)
+    def create(self, request):
+        # TODO: wrap in big try except clause
+        data = request.data
+        status_name = BonusRequestStatus.objects.get(status_name=data.get("status"))
+        creator = LannisterUser.objects.get(username=data.get("creator"))
+        reviewer = LannisterUser.objects.get(username=data.get("reviewer"))
+
+        # TODO: think about caching Role.objects.get(id=2) in order to minimize db hits from queries
+        if Role.objects.get(id=2) not in reviewer.roles.all():
+            return Response(
+                data={
+                    "response": "Provided reviewer username is not a user with actual Reviewer role"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if creator == reviewer:
+            return Response(
+                data={"response": "You cannot assign yourself to review your ticket"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            float(data["price_usd"])
+        except TypeError:
+            return Response(
+                data={"response": "Field 'price_usd' should be a decimal ie 123.00"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        new_bonus_request = BonusRequest.objects.create(
+            status=status_name,
+            creator=creator,
+            reviewer=reviewer,
+            description=data.get("description"),
+            bonus_type=data.get("bonus_type").capitalize(),
+            price_usd=data.get("price_usd"),
+        )
+        serializer = BonusRequestBaseSerializer(new_bonus_request)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class HistoryRequestViewSet(ReadOnlyModelViewSet):
@@ -65,3 +109,9 @@ class BonusRequestStatusViewSet(ModelViewSet):
     permission_classes = (IsAuthenticated,)
     serializer_class = BonusRequestStatusSerializer
     queryset = BonusRequestStatus.objects.all()
+
+
+class BonusTypeView(ModelViewSet):
+    queryset = BonusRequest.objects.values("bonus_type").distinct()
+    serializer_class = BonusTypeSerializer
+    http_method_names = ["get"]

--- a/backend/lannister_requests/views.py
+++ b/backend/lannister_requests/views.py
@@ -135,7 +135,7 @@ class HistoryRequestViewSet(ReadOnlyModelViewSet):
 
     """When get model of Roles implement permissions"""
 
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsUser,)
     serializer_class = FullHistorySerializer
     queryset = BonusRequest.objects.all()
 

--- a/backend/lannister_requests/views.py
+++ b/backend/lannister_requests/views.py
@@ -11,7 +11,6 @@ from lannister_requests.serializers import (
     BonusRequestStatusSerializer,
     BonusTypeSerializer,
 )
-from rest_framework.permissions import IsAuthenticated
 from lannister_requests.permissions import IsUser
 from rest_framework.response import Response
 from rest_framework import status
@@ -45,6 +44,19 @@ class BonusRequestViewSet(ModelViewSet):
         returns list if called on collection aka /api/requests/?user=demigorrgon
         returns single element on /api/requests/1?user=demigorrgon
         """
+        if self.request.query_params.get("reviewer") and self.request.query_params.get(
+            "reviewable"
+        ):
+            """
+            Example: GET /api/requests/?reviewer=demitest&reviewable=true
+            returns array of bonus requests assigned to provided reviewer and queries whether ticket's status is 'Created'
+            """
+            created_status = BonusRequestStatus.objects.get(status_name="Created")
+            queryset = self.queryset.filter(
+                reviewer__username=self.request.query_params.get("reviewer")
+            ).filter(status=created_status)
+            return queryset
+
         if self.request.query_params.get("user"):
             queryset = self.queryset.filter(
                 creator__username=self.request.query_params.get("user")
@@ -56,6 +68,7 @@ class BonusRequestViewSet(ModelViewSet):
                 reviewer__username=self.request.query_params.get("reviewer")
             )
             return queryset
+        # if self.request.query_params.get("")
         return self.queryset
 
     # def perform_create(self, serializer):

--- a/backend/lannister_requests/views.py
+++ b/backend/lannister_requests/views.py
@@ -15,6 +15,7 @@ from rest_framework.permissions import IsAuthenticated
 from lannister_requests.permissions import IsUser
 from rest_framework.response import Response
 from rest_framework import status
+import datetime
 
 
 class BonusRequestViewSet(ModelViewSet):
@@ -80,7 +81,9 @@ class BonusRequestViewSet(ModelViewSet):
                 data={"response": "Field 'price_usd' should be a decimal ie 123.00"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
+        deserialized_date = datetime.datetime.strptime(
+            data.get("payment_date"), "%Y-%m-%d %H:%M"
+        )
         new_bonus_request = BonusRequest.objects.create(
             status=status_name,
             creator=creator,
@@ -88,6 +91,7 @@ class BonusRequestViewSet(ModelViewSet):
             description=data.get("description"),
             bonus_type=data.get("bonus_type").capitalize(),
             price_usd=data.get("price_usd"),
+            payment_date=deserialized_date,
         )
         serializer = BonusRequestBaseSerializer(new_bonus_request)
         return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+version: '3.9'
+services:
+  # nginx:
+  #   context: .
+  #   ports:
+  #     - 80:80
+  #   volumes:
+  #     - .default.conf:/etc/nginx/conf.d/default.conf
+
+  #   depends_on:
+  #     - lannister-frontend
+
+  lannister-frontend:
+    image: lannister-frontend
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: ./frontend/Dockerfile
+    volumes:
+      - ./frontend/:/app/
+    ports:
+      - 8000:8000
+    depends_on:
+      - postgresdb
+
+  lannister-backend:
+    image: lannister-backend
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: ./backend/Dockerfile
+    volumes:
+      - ./backend/:/app/
+    ports:
+      - 8001:8001
+    depends_on:
+      - postgresdb
+
+  postgresdb:
+    image: postgres:latest
+    restart: always
+    environment:
+      - POSTGRES_USER=demigorrgon
+      - POSTGRES_PASSWORD=somepass1
+    ports:
+      - 5433:5433
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+
+volumes:
+  pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10-alpine3.15
+
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /app
+WORKDIR /app
+
+COPY ./frontend/ /app
+COPY requirements.txt /app
+COPY .env /app
+RUN apk add --no-cache --virtual .build-deps \
+    ca-certificates gcc postgresql-dev linux-headers musl-dev \
+    libffi-dev jpeg-dev zlib-dev 
+
+RUN pip3 install --upgrade pip
+RUN pip3 install -r requirements.txt
+CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/frontend/lannister_frontend/settings.py
+++ b/frontend/lannister_frontend/settings.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 import os
 
+
 load_dotenv()
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -133,3 +134,6 @@ STATIC_URL = "/static/"
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+BASE_BACKEND_URL = "http://127.0.0.1:8001/api/"
+CUSTOM_FRONTEND_HEADER = {"X-Slack-Frontend": "slack-frontend-header"}

--- a/frontend/lannister_frontend/settings.py
+++ b/frontend/lannister_frontend/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "lannister_slack",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/frontend/lannister_slack/urls.py
+++ b/frontend/lannister_slack/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 from lannister_slack.views import (
     SlackEventView,
     InteractivesHandler,
-    BonusRequestViewSet,
     RegisterUserCommandView,
     ChooseActionCommandView,
     ListRequestsCommandView,
@@ -12,10 +11,9 @@ from lannister_slack.views import (
     AddReviewerCommandView,
     RemoveReviewerCommandView,
     ListUsersCommandView,
-    BonusRequestStatusChangeHistoryView,
+    BonusRequestHistoryView,
     ListReviewableRequests,
 )
-from rest_framework.routers import DefaultRouter
 
 urlpatterns = [
     path("events", SlackEventView.as_view(), name="slack-events"),
@@ -30,7 +28,7 @@ urlpatterns = [
     path(
         "remove-reviewer", RemoveReviewerCommandView.as_view(), name="remove-reviewer"
     ),
-    path("history", BonusRequestStatusChangeHistoryView.as_view(), name="history"),
+    path("history", BonusRequestHistoryView.as_view(), name="history"),
     path("list-users", ListUsersCommandView.as_view(), name="list-users"),
     path(
         "list-requests-to-review",
@@ -38,7 +36,3 @@ urlpatterns = [
         name="list-requests-to-review",
     ),
 ]
-
-router = DefaultRouter()
-router.register("bonus-requests", BonusRequestViewSet)
-urlpatterns += router.urls


### PR DESCRIPTION
- [x] Replace all db queries with `requests` calls
- [x] Manual tests
- [x] Setup containers for both apps, docker-compose

**Reworked permission from `lannister_requests.permissions`, now it allows custom "X-Slack-Frontend" header to bypass JWT auth. It may lead to security breach, but drastically simplifies frontend app. Pls don't remove that header from `IsUser` permission**

 - Changed url mapping in `backend.api_workers.urls` to viewset-like (`list` for collection, `detail` for single object) urls. `api/workers/<single_item>` and `api/workers/` for collection is kinda anti-REST and can mislead ppl.

- Added some functionality in `api_workers.views` to be able to query data through API from frontend app

- Extended `BonusRequestViewSet` with explicit `POST`, `PATCH` requests processing. Could be refactored with helper functions or replaced with serializer methods (`create`, `update`)
- Added query params to `BonusRequestViewSet` to be able to query models from frontend.

- Explicitly serialized `creator`, `reviewer`, `status` and some other fields with human-readable text (instead of ids). Removes a need in redundant API calls to backend.

- Added simple docker-compose setup. 

Can't really make PR smaller in size, spamming with PRs on every slash command refactor is kinda cringe.